### PR TITLE
BVS-3715 skip warning when deploying on fuel 6.1

### DIFF
--- a/openstack/big_patch.py
+++ b/openstack/big_patch.py
@@ -304,6 +304,7 @@ class FuelEnvironment(SSHEnvironment):
         except Exception as e:
             raise Exception("Error encountered trying to execute the Fuel "
                             "CLI:\n%s" % e)
+        errors = self.eliminate_harmless_deprecated_warning(errors)
         if errors:
             raise Exception("Error Loading cluster %s:\n%s"
                             % (environment_id, errors))
@@ -336,6 +337,17 @@ class FuelEnvironment(SSHEnvironment):
             raise Exception("Could not parse node list:\n%s" % output)
         for node in self.nodes:
             self.node_settings[node] = self.get_node_config(node)
+
+    def eliminate_harmless_deprecated_warning(self, errors):
+        # ignore deprecated warning in Fuel6.1
+        actual_errors = []
+        errors = errors.splitlines()
+        for e in errors:
+            # ignore some warnings
+            if "DEPRECATION WARNING: /etc/fuel/client/config.yaml exists" in e:
+                continue
+            actual_errors.append(e)
+        return '\n'.join(actual_errors)
 
     def get_node_config(self, node):
         print "Retrieving Fuel configuration for node %s..." % node


### PR DESCRIPTION
Reviewer: @kjiang @xinwu 

warning that causes failure:

```
[root@fuel ~]# python big_patch.py -f 3 -s 10.8.29.14:8000,10.8.29.15:8000 -a admin:adminadmin -r Juno
Big Patch Version master:1.1.14
Retrieving general Fuel settings...
Traceback (most recent call last):
  File "big_patch.py", line 1865, in <module>
    specific_nodes=specific_nodes)
  File "big_patch.py", line 319, in __init__
    % (environment_id, errors))
Exception: Error Loading cluster 3:
DEPRECATION WARNING: /etc/fuel/client/config.yaml exists and will be used as the source for settings. This behavior is deprecated. Please specify the path to your custom settings file in the FUELCLIENT_CUSTOM_SETTINGS environment variable.
```

let me know if we want to pass that setting instead of skipping the warning. this should work as it would proceed with the default as it was in Fuel6.0
